### PR TITLE
Set canvas size after maze image load

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,13 +96,12 @@ const zamoraGame = {
 
   /* -------- iniciar -------- */
   start(){
-    canvas.width  = 609;
-    canvas.height = 528;
-
     zamoraMusic.currentTime = 0;
     playZamoraMusic();
 
     const begin = () => {
+      canvas.width  = mazeImg.width;
+      canvas.height = mazeImg.height;
       /* capturar bitmap del laberinto */
       const off = Object.assign(document.createElement('canvas'), {width:canvas.width, height:canvas.height});
       off.getContext('2d').drawImage(mazeImg,0,0,canvas.width,canvas.height);


### PR DESCRIPTION
## Summary
- resize the game canvas after `mazeImg` loads

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ca58a6bc88332baccc32b40aa4109