### PR TITLE
Improve bullet visibility after collecting power-up

### DIFF
--- a/index.html
+++ b/index.html
@@ -313,10 +313,12 @@ const zamoraGame = {
   shoot(){
     const speed=this.step*2;
     this.bullets.push({
-      x:this.p.x + this.SPR,
+      x:this.p.x + this.SPR/2,
       y:this.p.y + this.SPR/2,
-      dx:speed,
-      dy:0
+      dx:speed*this.facing.x,
+      dy:speed*this.facing.y,
+      size:8,
+      hue:0
     });
   },
 
@@ -403,7 +405,8 @@ const zamoraGame = {
     /* mover balas */
     for(const b of this.bullets){
       b.x+=b.dx; b.y+=b.dy;
-      if(this.blocked(b.x, b.y, 4) ||
+      b.hue = (b.hue + 10) % 360;
+      if(this.blocked(b.x, b.y, b.size) ||
          b.x<0 || b.y<0 || b.x>canvas.width || b.y>canvas.height){
         b.remove=true;
         continue;
@@ -457,9 +460,9 @@ const zamoraGame = {
       ctx.fillStyle='#FFD700';
       ctx.fillRect(this.power.x, this.power.y, this.SPR/2, this.SPR/2);
     }
-    ctx.fillStyle='cyan';
     for(const b of this.bullets){
-      ctx.fillRect(b.x,b.y,4,4);
+      ctx.fillStyle=`hsl(${b.hue},100%,60%)`;
+      ctx.fillRect(b.x,b.y,b.size,b.size);
     }
 
     /* cartel neón */


### PR DESCRIPTION
## Summary
- adjust bullet to spawn from hero center and follow facing direction
- enlarge bullet size and cycle its colors
- draw bullets using animated hue

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d83cabd7083329185c2a3ddeca203